### PR TITLE
Automatically close Oculus and SteamVR when the user leaves VR.

### DIFF
--- a/OculusKiller/Program.cs
+++ b/OculusKiller/Program.cs
@@ -24,6 +24,62 @@ namespace OculusKiller
                     {
                         Process vrStartupProcess = Process.Start(vrStartupPath);
                         vrStartupProcess.WaitForExit();
+
+                        // At this point, vrstartup.exe should have launched vrmonitor.exe.
+                        // This is the one we actually need to wait for to exit when the user clicks "EXIT VR" in the SteamVR dashboard.
+                        var vrMonitorProcesses = Process.GetProcessesByName("vrmonitor");
+                        if (vrMonitorProcesses.Length > 0)
+                        {
+                            foreach (var vrMonitorProcess in vrMonitorProcesses)
+                            {
+                                vrMonitorProcess.WaitForExit();
+                            }
+
+                            // Since exiting SteamVR doesn't actually tell the OVRService to disconnect the headset,
+                            // the OVRService will still immediately re-launch if we exit here.
+                            // Even if we return the same exit code as the official OculusDash.exe
+                            // does when the user presses Quit, which is 0xc0000005, it doesn't stop OVRServer from re-launching us.
+
+#if false // Doesn't work without admin privileges.
+                            // The only way we know of to prevent this is to stop the OVRService service or kill the OVRServer process.
+                            var ovrService = new System.ServiceProcess.ServiceController("OVRService");
+                            ovrService.Stop(); 
+                            ovrService.WaitForStatus(System.ServiceProcess.ServiceControllerStatus.Stopped);
+                            // Restart it so that it's ready for the next time the user wants to connect their headset.
+                            ovrService.Start();
+#endif
+
+#if false // Thwarted by Oculus Client's "Are you sure you want to quit?" dialog.
+                            // Gracefully stop the OculusClient process.
+                            var oculusClientProcesses = Process.GetProcessesByName("OculusClient");
+                            if (oculusClientProcesses.Length > 0)
+                            {
+                                foreach (var oculusClientProcess in oculusClientProcesses)
+                                {
+                                    oculusClientProcess.CloseMainWindow();
+                                }
+                                foreach (var oculusClientProcess in oculusClientProcesses)
+                                {
+                                    oculusClientProcess.WaitForExit();
+                                }
+                            }
+                            else
+                                MessageBox.Show("Could not find OculusClient process.");
+#endif
+
+                            // Last resort: Kill the OVRServer process (might end in _x86 or _x64).
+                            foreach (var ovrServerProcess in Process.GetProcesses().Where(p => p.ProcessName.StartsWith("OVRServer")))
+                            {
+                                ovrServerProcess.Kill();
+                            }
+
+                            // The OVRServiceLauncher will immediately re-launch OVRServer and the OculusClient window,
+                            // which is kind of annoying, but at least it will set our audio/microphone devices back to the default ones.
+                            
+                            // We can safely exit now, since killing the OVRServer process already disconnected the headset.
+                        }
+                        else
+                            MessageBox.Show("Could not find vrmonitor process.");
                     }
                     else
                         MessageBox.Show("SteamVR does not exist in installation directory.");

--- a/OculusKiller/Program.cs
+++ b/OculusKiller/Program.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Windows.Forms;
 using System.Web.Script.Serialization;
+using System.Linq;
 
 namespace OculusKiller
 {


### PR DESCRIPTION
The OculusKiller's current behavior causes SteamVR to immediately restart after exiting it, effectively trapping the headset in SteamVR land with no way to exit.  The only way to exit is to close the Oculus app, but then SteamVR sometimes freaks out and uses 100% CPU/GPU for a few minutes until it realizes the headset isn't connected anymore.

This pull request makes OculusKiller wait until SteamVR has exited, and then it kills the OVRServer (effectively disconnecting the headset) before exiting.  This means that clicking "EXIT VR" in the SteamVR dash does what you expect and disconnects the headset.

It also watches for the case where the user closed the Oculus Client app or stopped the OVRService before exiting SteamVR.  In this case it closes SteamVR automatically to avoid it hanging/spinning looking for the headset.